### PR TITLE
Correctly invalidate connections on failure.

### DIFF
--- a/django_postgrespool/base.py
+++ b/django_postgrespool/base.py
@@ -108,7 +108,7 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         self.creation = DatabaseCreation(self)
 
     def _cursor(self):
-        if self.connection is None:
+        if self.connection is None or self.connection.is_valid == False:
             self.connection = db_pool.connect(**self._get_conn_params())
             self.connection.set_client_encoding('UTF8')
             tz = 'UTC' if settings.USE_TZ else self.settings_dict.get('TIME_ZONE')


### PR DESCRIPTION
_cursor does not check if the connection is still valid, meaning that
once a connection has been marked as invalid it will attempt to get an
sqlalchemy cursor on a broken connection and throw an exception. This
commit causes the connection to be validated when using the cursor,
triggering a new connection to be fetched from the pool if the previous
one has been marked as dead.
