### PR TITLE
Handle rollback/commit with failed connection

### DIFF
--- a/django_postgrespool/base.py
+++ b/django_postgrespool/base.py
@@ -134,6 +134,14 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         cursor.tzinfo_factory = utc_tzinfo_factory if settings.USE_TZ else None
         return CursorWrapper(cursor, self.connection)
 
+    def _commit(self):
+        if self.connection is not None and self.connection.is_valid:
+            return self.connection.commit()
+
+    def _rollback(self):
+        if self.connection is not None and self.connection.is_valid:
+            return self.connection.rollback()
+
     def _dispose(self):
         """Dispose of the pool for this instance, closing all connections."""
         self.close()


### PR DESCRIPTION
If a rollback or commit is attempted after the connection has failed
Django's BaseDatabaseWrapper does not know to check the validity of the
database connection and may fail due to the connection already being
closed. This is especially a problem when django is attempting to
automatically roll back transactions at the end of a request that has
already failed due to a database error and will result in the default
"Server Error" page being displayed as django cannot handle the error.
