### PR TITLE
Fix pool not working bugs and autocommit

### DIFF
--- a/django_postgrespool/base.py
+++ b/django_postgrespool/base.py
@@ -95,3 +95,20 @@ class DatabaseWrapper(Psycopg2DatabaseWrapper):
         else:
             pool.dispose()
             del db_pool.pools[key]
+
+    def get_new_connection(self, conn_params):
+        # get new connection through pool, not creating a new one outside.
+        connection = db_pool.connect(**conn_params)
+        return connection
+
+    def _set_autocommit(self, autocommit):
+        # fix autocommit setting not working in proxied connection
+        with self.wrap_database_errors:
+            if self.psycopg2_version >= (2, 4, 2):
+                self.connection.connection.autocommit = autocommit
+            else:
+                if autocommit:
+                    level = psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+                else:
+                    level = self.isolation_level
+                self.connection.connection.set_isolation_level(level)


### PR DESCRIPTION
The original implementation do not get new connection from the pool so it is actually not working.
and when creating test db, there's always a 'CREATE DATABASE' in a transaction block error due to
the lack of reimplementation of `_set_autocommit`method for the proxied connection.

I tried to fix these two bugs and it is now working in Django 1.7, I think it should also work for older
version.
