### PR TITLE
Remove non-ASCII characters from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,8 @@ Optionally, you can provide additional options to pass to SQLAlchemy's pool crea
 
 Here's a basic explanation of two of these options:
 
-* **pool_size** – The *minimum* number of connections to maintain in the pool.
-* **max_overflow** – The maximum *overflow* size of the pool. This is not the maximum size of the pool.
+* **pool_size** - The *minimum* number of connections to maintain in the pool.
+* **max_overflow** - The maximum *overflow* size of the pool. This is not the maximum size of the pool.
 
 The total number of "sleeping" connections the pool will allow is ``pool_size``.
 The total simultaneous connections the pool will allow is ``pool_size + max_overflow``.


### PR DESCRIPTION
Replace the 2 EN-DASH (https://www.compart.com/en/unicode/U+2013) characters in
README.rst with the ASCII character HYPNEN-MINUS
(http://www.fileformat.info/info/unicode/char/2d/index.htm).  Strictly speaking,
the EN-DASH character is more correct but using a non ASCII character can lead 
to problems when installing the package like exception thrown by pip running
setup.py like 

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1200:
ordinal not in range(128)

Of course the problem itself is probably due to the environment for whatever
reason not supporting UTF-8 and/or the setup.py script, but this is all probably
irrelevant and causing undue stress to the end-user wanting to just install this 
package.